### PR TITLE
Publish only legal pages on GitHub Pages

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -2,28 +2,20 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 
-// This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
-
 const config: Config = {
-  // Ajustar com o nome do projeto
-  title: "RateioApp Docs",
-  baseUrl: "/rateio-app/",
-  projectName: "rateio-app",
-  tagline: "Documentação do projeto RateioApp",
-
-
+  title: "Por Partes",
+  tagline: "Informações legais e suporte do aplicativo Por Partes",
   favicon: "img/favicon.ico",
-  // Set the production url of your site here
-  url: "https://InteliJR.github.io",
-  organizationName: "InteliJR", // Usually your GitHub org/user name.
+
+  url: "https://intelijr.github.io",
+  baseUrl: "/rateio-app/",
+  organizationName: "InteliJR",
+  projectName: "rateio-app",
   trailingSlash: false,
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
-  // Even if you don't use internationalization, you can use this field to set
-  // useful metadata like html lang. For example, if your site is Chinese, you
-  // may want to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: "pt-br",
     locales: ["pt-br"],
@@ -33,10 +25,7 @@ const config: Config = {
     [
       "classic",
       {
-        docs: {
-          sidebarPath: "./sidebars.ts",
-          // Please change this to your repo.
-        },
+        docs: false,
         blog: false,
         theme: {
           customCss: "./src/css/custom.css",
@@ -46,22 +35,39 @@ const config: Config = {
   ],
 
   themeConfig: {
-    // Replace with your project's social card
     navbar: {
-      title: "Início",
+      title: "Por Partes",
       items: [
         {
-          type: "docSidebar",
-          sidebarId: "tutorialSidebar",
+          to: "/politica-de-privacidade",
           position: "left",
-          label: "Documentação",
+          label: "Política de Privacidade",
+        },
+        {
+          to: "/excluir-conta",
+          position: "left",
+          label: "Exclusão de Conta",
         },
       ],
     },
     footer: {
       style: "dark",
-
-      copyright: `Copyright © ${new Date().getFullYear()} RateioApp, Inc. Built with Docusaurus.`,
+      links: [
+        {
+          title: "Informações legais",
+          items: [
+            {
+              label: "Política de Privacidade",
+              to: "/politica-de-privacidade",
+            },
+            {
+              label: "Exclusão de Conta",
+              to: "/excluir-conta",
+            },
+          ],
+        },
+      ],
+      copyright: `Copyright © ${new Date().getFullYear()} Por Partes.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/docs/src/pages/excluir-conta.md
+++ b/docs/src/pages/excluir-conta.md
@@ -80,7 +80,7 @@ Responderemos solicitações de exclusão em até 15 DIAS, salvo quando for nece
 
 Para mais detalhes sobre coleta, uso, compartilhamento, retenção e segurança dos dados, consulte a Política de Privacidade:
 
-[URL PÚBLICA DA POLÍTICA DE PRIVACIDADE]
+https://intelijr.github.io/rateio-app/politica-de-privacidade
 
 ## Contato
 

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -1,118 +1,42 @@
+.main {
+  min-height: calc(100vh - var(--ifm-navbar-height));
+}
+
 .heroBanner {
+  display: flex;
+  align-items: center;
+  min-height: 60vh;
   padding: 4rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-}
-
-/* Gradiente claro */
-.lightGradient {
-  background: radial-gradient(circle at bottom right, #ffffff, #e6e6e6);
-}
-
-/* Gradiente escuro */
-.darkGradient {
-  background: radial-gradient(circle at top left, #1a1a1a, #000000);
-}
-
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem 0;
-  }
-
-  .headerContent {
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    gap: 40px;
-  }
-
-  .textContent {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: column;
-    text-align: center;
-  }
-
-  .buttons {
-    margin-top: 0 !important;
-  }
-}
-
-.headerContent {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.textContent {
-  flex: 1;
   text-align: left;
-  min-width: 300px;
 }
 
-.logoContent {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-width: 250px;
-}
-
-.logoImage {
-  width: 100%;
-  max-width: 300px;
-  min-width: 200px;
-  height: auto;
+.content {
+  max-width: 720px;
 }
 
 .buttons {
   display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 2rem;
 }
 
-/* Botão base */
-.docButton {
-  border: none;
-  font-weight: 600;
-  padding: 0.75rem 2rem;
-  font-size: 1.1rem;
-  border-radius: 8px;
-  transition: background-color 0.3s ease, color 0.3s ease, transform 0.2s;
-  text-decoration: none;
+.button {
+  min-width: 220px;
 }
 
-/* Tema claro */
-.lightButton {
-  background-color: #901616;
-  color: #ffffff;
-}
+@media screen and (max-width: 996px) {
+  .heroBanner {
+    min-height: auto;
+    padding: 3rem 0;
+    text-align: center;
+  }
 
-.lightButton:hover {
-  background-color: #5e0d0d;
-  color: #fff;
-  transform: translateY(-2px);
-}
+  .content {
+    margin: 0 auto;
+  }
 
-/* Tema escuro */
-.darkButton {
-  background-color: #ffffff;
-  color: #1a1a1a;
-}
-
-.darkButton:hover {
-  background-color: #e0b4b4;
-  color: #000000;
-  transform: translateY(-2px);
-}
-
-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
+  .buttons {
+    justify-content: center;
+  }
 }

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,76 +1,44 @@
 import type { ReactNode } from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
-import HomepageFeatures from "@site/src/components/HomepageFeatures";
 import Heading from "@theme/Heading";
 
 import styles from "./index.module.css";
 
-import { useColorMode } from "@docusaurus/theme-common";
-import useBaseUrl from "@docusaurus/useBaseUrl";
-
-function HomepageHeader() {
-  const { siteConfig } = useDocusaurusContext();
-  const { colorMode } = useColorMode();
-
-  const isDarkTheme = colorMode === "dark";
-
-  const logoSrc = isDarkTheme
-    ? useBaseUrl("/img/ijLogoDark.png")
-    : useBaseUrl("/img/ijLogoLight.png");
-
-  return (
-    <header
-      className={clsx(
-        "hero",
-        styles.heroBanner,
-        isDarkTheme ? styles.darkGradient : styles.lightGradient
-      )}
-    >
-      <div className="container">
-        <div className={styles.headerContent}>
-          <div className={styles.textContent}>
-            <Heading as="h1" className="hero__title">
-              {siteConfig.title}
-            </Heading>
-            <p className="hero__subtitle">{siteConfig.tagline}</p>
-            <div className={styles.buttons}>
-              <Link
-                className={clsx(
-                  styles.docButton,
-                  isDarkTheme ? styles.darkButton : styles.lightButton
-                )}
-                to="/docs/intro"
-              >
-                Acesse a documentação
-              </Link>
-            </div>
-          </div>
-          <div className={styles.logoContent}>
-            <img
-              src={logoSrc}
-              alt="Logo da Inteli Junior"
-              className={styles.logoImage}
-            />
-          </div>
-        </div>
-      </div>
-    </header>
-  );
-}
-
 export default function Home(): ReactNode {
-  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
+      title="Por Partes"
+      description="Informações legais e suporte do aplicativo Por Partes"
     >
-      <HomepageHeader />
-      <main>
-        <HomepageFeatures />
+      <main className={styles.main}>
+        <section className={clsx("hero", styles.heroBanner)}>
+          <div className="container">
+            <div className={styles.content}>
+              <Heading as="h1" className="hero__title">
+                Por Partes
+              </Heading>
+              <p className="hero__subtitle">
+                Informações legais e suporte para usuários do aplicativo.
+              </p>
+              <div className={styles.buttons}>
+                <Link
+                  className={clsx("button button--primary", styles.button)}
+                  to="/politica-de-privacidade"
+                >
+                  Política de Privacidade
+                </Link>
+                <Link
+                  className={clsx("button button--secondary", styles.button)}
+                  to="/excluir-conta"
+                >
+                  Exclusão de Conta
+                </Link>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
     </Layout>
   );

--- a/docs/src/pages/politica-de-privacidade.md
+++ b/docs/src/pages/politica-de-privacidade.md
@@ -127,7 +127,7 @@ Ao excluir a conta pelo app, apagamos os dados associados à conta, incluindo pe
 
 Se o usuário não conseguir acessar o app, também pode iniciar uma solicitação de exclusão pela página:
 
-[URL PÚBLICA DA PÁGINA DE EXCLUSÃO DE CONTA]
+https://intelijr.github.io/rateio-app/excluir-conta
 
 ou pelo e-mail:
 


### PR DESCRIPTION
## Summary
- Disable the Docusaurus docs section so GitHub Pages no longer exposes development documentation.
- Move the privacy policy and account deletion pages into `docs/src/pages` for public page routes.
- Replace the public URL placeholders with the expected GitHub Pages URLs.
- Simplify the public homepage and navbar to link only to legal/support pages.

## Public URLs after deploy
- Privacy Policy: https://intelijr.github.io/rateio-app/politica-de-privacidade
- Account deletion: https://intelijr.github.io/rateio-app/excluir-conta

## Validation
- `git diff --cached --check` before commit
- `rg` check confirmed no remaining public URL placeholders, `/docs/` links, or `docSidebar` references in the public Docusaurus pages/config

## Not run
- `docs`: `npm run build` could not be completed locally because `docusaurus` was not installed and both `npm install` and `npm ci --no-audit --no-fund` hung in this environment after dependency warnings.