### PR TITLE
Fix OCR extraction for Brazilian receipt values

### DIFF
--- a/backend/src/ocr/dto/ocr-result.dto.spec.ts
+++ b/backend/src/ocr/dto/ocr-result.dto.spec.ts
@@ -1,0 +1,50 @@
+import 'reflect-metadata';
+import { OcrResultDto } from './ocr-result.dto';
+
+describe('OcrResultDto', () => {
+  it('normalizes pt-BR currency strings before validation', async () => {
+    const dto = await OcrResultDto.fromOpenAiResponse({
+      establishmentName: 'Mercado Teste',
+      items: [
+        {
+          name: 'Coca Cola',
+          quantity: '2',
+          unitPrice: 'R$ 5,50',
+          totalPrice: 'R$ 11,00',
+        },
+      ],
+      totalAmount: 'R$ 11,00',
+    });
+
+    expect(dto.totalAmount).toBe(11);
+    expect(dto.items).toHaveLength(1);
+    expect(dto.items[0]).toMatchObject({
+      name: 'Coca Cola',
+      quantity: 2,
+      unitPrice: 5.5,
+      totalPrice: 11,
+    });
+  });
+
+  it('accepts common Portuguese field aliases', async () => {
+    const dto = await OcrResultDto.fromOpenAiResponse({
+      establishmentName: 'Padaria Teste',
+      items: [
+        {
+          nome: 'Pao frances',
+          quantidade: '3',
+          valorTotal: 'R$ 9,00',
+        },
+      ],
+      totalGeral: '9,00',
+    });
+
+    expect(dto.totalAmount).toBe(9);
+    expect(dto.items[0]).toMatchObject({
+      name: 'Pao frances',
+      quantity: 3,
+      unitPrice: 3,
+      totalPrice: 9,
+    });
+  });
+});

--- a/backend/src/ocr/dto/ocr-result.dto.ts
+++ b/backend/src/ocr/dto/ocr-result.dto.ts
@@ -16,6 +16,7 @@ import { validate } from 'class-validator';
 import { OcrItemDto } from './ocr-item.dto';
 import { OcrTaxDto } from './ocr-tax.dto';
 import { OcrDiscountDto } from './ocr-discount.dto';
+import { parseOcrNumber, parseOcrQuantity, roundMoney } from '../ocr-number.util';
 
 export interface OcrResult {
   rawText: string;
@@ -156,9 +157,45 @@ export class OcrResultDto {
 
     // Aplicar defaults antes da conversão
     if (processedData.items && Array.isArray(processedData.items)) {
-      processedData.items = processedData.items.map((item: any) => ({
-        ...item,
-        quantity: item.quantity ?? 1,
+      processedData.items = processedData.items.map((item: any) =>
+        OcrResultDto.normalizeItem(item),
+      );
+    }
+
+    processedData.totalAmount = OcrResultDto.normalizePositiveMoney(
+      processedData.totalAmount ??
+        processedData.total ??
+        processedData.valorTotal ??
+        processedData.valor_total ??
+        processedData.totalGeral ??
+        processedData.total_geral,
+    );
+    processedData.subtotal = OcrResultDto.normalizePositiveMoney(
+      processedData.subtotal,
+      true,
+    );
+
+    if (processedData.taxes && Array.isArray(processedData.taxes)) {
+      processedData.taxes = processedData.taxes.map((tax: any) => ({
+        ...tax,
+        value: OcrResultDto.normalizePositiveMoney(
+          tax.value ?? tax.valor ?? tax.amount,
+          true,
+        ),
+        percentage: OcrResultDto.normalizePositiveMoney(
+          tax.percentage ?? tax.percentual ?? tax.percent,
+          true,
+        ),
+      }));
+    }
+
+    if (processedData.discounts && Array.isArray(processedData.discounts)) {
+      processedData.discounts = processedData.discounts.map((discount: any) => ({
+        ...discount,
+        value: OcrResultDto.normalizePositiveMoney(
+          discount.value ?? discount.valor ?? discount.amount,
+          true,
+        ),
       }));
     }
     if (!processedData.currency) {
@@ -181,6 +218,80 @@ export class OcrResultDto {
     }
 
     return ocrResultDto;
+  }
+
+  private static normalizeItem(item: any) {
+    const quantity = parseOcrQuantity(
+      item.quantity ?? item.quantidade ?? item.qty ?? item.qtd ?? 1,
+    );
+    const unitPrice = parseOcrNumber(
+      item.unitPrice ??
+        item.unit_price ??
+        item.precoUnitario ??
+        item.preco_unitario ??
+        item.valorUnitario ??
+        item.valor_unitario ??
+        item.price ??
+        item.preco ??
+        item.valor,
+    );
+    const totalPrice = parseOcrNumber(
+      item.totalPrice ??
+        item.total_price ??
+        item.precoTotal ??
+        item.preco_total ??
+        item.valorTotal ??
+        item.valor_total ??
+        item.total,
+    );
+    const normalizedUnitPrice =
+      unitPrice && unitPrice > 0
+        ? unitPrice
+        : totalPrice && totalPrice > 0
+          ? totalPrice / quantity
+          : undefined;
+    const normalizedTotalPrice =
+      totalPrice && totalPrice > 0
+        ? totalPrice
+        : normalizedUnitPrice && normalizedUnitPrice > 0
+          ? normalizedUnitPrice * quantity
+          : undefined;
+
+    return {
+      ...item,
+      name:
+        item.name ??
+        item.nome ??
+        item.description ??
+        item.descricao ??
+        item.produto,
+      quantity,
+      unitPrice:
+        normalizedUnitPrice === undefined
+          ? undefined
+          : roundMoney(normalizedUnitPrice),
+      totalPrice:
+        normalizedTotalPrice === undefined
+          ? undefined
+          : roundMoney(normalizedTotalPrice),
+    };
+  }
+
+  private static normalizePositiveMoney(
+    value: unknown,
+    allowZero = false,
+  ): number | undefined {
+    const parsed = parseOcrNumber(value);
+    if (parsed === undefined) {
+      return undefined;
+    }
+
+    const normalized = Math.abs(parsed);
+    if (normalized > 0 || allowZero) {
+      return roundMoney(normalized);
+    }
+
+    return undefined;
   }
 
   /**

--- a/backend/src/ocr/ocr-number.util.spec.ts
+++ b/backend/src/ocr/ocr-number.util.spec.ts
@@ -1,0 +1,21 @@
+import { parseOcrNumber, parseOcrQuantity } from './ocr-number.util';
+
+describe('OCR number parsing', () => {
+  it('parses Brazilian currency strings', () => {
+    expect(parseOcrNumber('R$ 1.234,56')).toBe(1234.56);
+    expect(parseOcrNumber('1.234')).toBe(1234);
+    expect(parseOcrNumber('5,50')).toBe(5.5);
+    expect(parseOcrNumber('11,00')).toBe(11);
+  });
+
+  it('parses plain JSON number strings', () => {
+    expect(parseOcrNumber('1234.56')).toBe(1234.56);
+    expect(parseOcrNumber('10')).toBe(10);
+  });
+
+  it('normalizes quantities', () => {
+    expect(parseOcrQuantity('2')).toBe(2);
+    expect(parseOcrQuantity('2x')).toBe(2);
+    expect(parseOcrQuantity(undefined)).toBe(1);
+  });
+});

--- a/backend/src/ocr/ocr-number.util.ts
+++ b/backend/src/ocr/ocr-number.util.ts
@@ -1,0 +1,77 @@
+export function parseOcrNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined;
+  }
+
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const sanitized = trimmed
+    .replace(/\s/g, '')
+    .replace(/[^\d,.-]/g, '');
+
+  if (!sanitized || sanitized === '-' || sanitized === ',' || sanitized === '.') {
+    return undefined;
+  }
+
+  const hasComma = sanitized.includes(',');
+  const hasDot = sanitized.includes('.');
+  let normalized = sanitized;
+
+  if (hasComma && hasDot) {
+    const lastComma = sanitized.lastIndexOf(',');
+    const lastDot = sanitized.lastIndexOf('.');
+    const decimalSeparator = lastComma > lastDot ? ',' : '.';
+    const thousandsSeparator = decimalSeparator === ',' ? '.' : ',';
+
+    normalized = sanitized
+      .replace(new RegExp(`\\${thousandsSeparator}`, 'g'), '')
+      .replace(decimalSeparator, '.');
+  } else if (hasComma) {
+    normalized = normalizeSingleSeparator(sanitized, ',');
+  } else if (hasDot) {
+    normalized = normalizeSingleSeparator(sanitized, '.');
+  }
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function parseOcrQuantity(value: unknown): number {
+  const parsed = parseOcrNumber(value);
+  if (!parsed || parsed < 1) {
+    return 1;
+  }
+
+  return Math.max(1, Math.floor(parsed));
+}
+
+export function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function normalizeSingleSeparator(value: string, separator: ',' | '.'): string {
+  const parts = value.split(separator);
+
+  if (parts.length <= 2) {
+    const decimalPart = parts[1];
+    if (decimalPart && decimalPart.length === 3) {
+      return parts.join('');
+    }
+
+    return value.replace(separator, '.');
+  }
+
+  const decimalPart = parts[parts.length - 1];
+  if (decimalPart.length === 2) {
+    return `${parts.slice(0, -1).join('')}.${decimalPart}`;
+  }
+
+  return parts.join('');
+}

--- a/backend/src/ocr/ocr.service.spec.ts
+++ b/backend/src/ocr/ocr.service.spec.ts
@@ -1,0 +1,64 @@
+import 'reflect-metadata';
+import { OcrService } from './ocr.service';
+
+describe('OcrService parsing fallback', () => {
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.OPENAI_MODEL = 'gpt-4.1-mini';
+  });
+
+  it('keeps items when fallback JSON contains pt-BR currency strings', () => {
+    const service = new OcrService();
+    const parsed = (service as any).parseJsonResponseUnvalidated(
+      {
+        establishmentName: 'Mercado Teste',
+        items: [
+          {
+            name: 'Coca Cola',
+            quantity: '2',
+            unitPrice: 'R$ 5,50',
+            totalPrice: 'R$ 11,00',
+          },
+        ],
+        totalAmount: 'R$ 11,00',
+      },
+      '',
+    );
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]).toMatchObject({
+      name: 'Coca Cola',
+      quantity: 2,
+      unitPrice: 5.5,
+      totalPrice: 11,
+    });
+    expect(parsed.totalAmount).toBe(11);
+  });
+
+  it('keeps items when fallback JSON uses Portuguese field names', () => {
+    const service = new OcrService();
+    const parsed = (service as any).parseJsonResponseUnvalidated(
+      {
+        establishmentName: 'Padaria Teste',
+        items: [
+          {
+            nome: 'Pao frances',
+            quantidade: '3',
+            valorTotal: 'R$ 9,00',
+          },
+        ],
+        totalGeral: 'R$ 9,00',
+      },
+      '',
+    );
+
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0]).toMatchObject({
+      name: 'Pao frances',
+      quantity: 3,
+      unitPrice: 3,
+      totalPrice: 9,
+    });
+    expect(parsed.totalAmount).toBe(9);
+  });
+});

--- a/backend/src/ocr/ocr.service.ts
+++ b/backend/src/ocr/ocr.service.ts
@@ -7,6 +7,7 @@ import {
 import OpenAI, { APIError, APIConnectionError, APIConnectionTimeoutError } from 'openai';
 import { ValidationError } from 'class-validator';
 import { OcrResultDto, OcrResult } from './dto/ocr-result.dto';
+import { parseOcrNumber, parseOcrQuantity, roundMoney } from './ocr-number.util';
 
 
 @Injectable()
@@ -305,19 +306,52 @@ Retorne o JSON seguindo exatamente a estrutura acima, baseando-se nos exemplos f
     // Tentar extrair itens do JSON
     if (jsonData.items && Array.isArray(jsonData.items)) {
       for (const item of jsonData.items) {
-        if (item && item.name) {
-          const name = String(item.name).trim();
-          const quantity = item.quantity ? Math.max(1, Math.floor(Number(item.quantity))) : 1;
-          const unitPrice = item.unitPrice ? Math.max(0, Number(item.unitPrice)) : 0;
-          const totalPrice = item.totalPrice ? Math.max(0, Number(item.totalPrice)) : 0;
+        if (item) {
+          const name = String(
+            item.name ??
+              item.nome ??
+              item.description ??
+              item.descricao ??
+              item.produto ??
+              '',
+          ).trim();
+          const quantity = parseOcrQuantity(
+            item.quantity ?? item.quantidade ?? item.qty ?? item.qtd ?? 1,
+          );
+          const unitPrice = Math.max(
+            0,
+            parseOcrNumber(
+              item.unitPrice ??
+                item.unit_price ??
+                item.precoUnitario ??
+                item.preco_unitario ??
+                item.valorUnitario ??
+                item.valor_unitario ??
+                item.price ??
+                item.preco ??
+                item.valor,
+            ) ?? 0,
+          );
+          const totalPrice = Math.max(
+            0,
+            parseOcrNumber(
+              item.totalPrice ??
+                item.total_price ??
+                item.precoTotal ??
+                item.preco_total ??
+                item.valorTotal ??
+                item.valor_total ??
+                item.total,
+            ) ?? 0,
+          );
           
           // Só adicionar se tiver nome válido e preço válido
           if (name.length > 0 && (unitPrice > 0 || totalPrice > 0)) {
             items.push({
               name,
               quantity,
-              unitPrice: unitPrice > 0 ? unitPrice : (totalPrice / quantity),
-              totalPrice: totalPrice > 0 ? totalPrice : (unitPrice * quantity),
+              unitPrice: roundMoney(unitPrice > 0 ? unitPrice : (totalPrice / quantity)),
+              totalPrice: roundMoney(totalPrice > 0 ? totalPrice : (unitPrice * quantity)),
             });
           }
         }
@@ -325,12 +359,19 @@ Retorne o JSON seguindo exatamente a estrutura acima, baseando-se nos exemplos f
     }
 
     // Extrair outros campos
-    const totalAmount = jsonData.totalAmount ? Number(jsonData.totalAmount) : undefined;
+    const totalAmount = parseOcrNumber(
+      jsonData.totalAmount ??
+        jsonData.total ??
+        jsonData.valorTotal ??
+        jsonData.valor_total ??
+        jsonData.totalGeral ??
+        jsonData.total_geral,
+    );
     const establishmentName = jsonData.establishmentName ? String(jsonData.establishmentName).trim() : undefined;
 
     return {
       items,
-      totalAmount: totalAmount && totalAmount > 0 ? totalAmount : undefined,
+      totalAmount: totalAmount && totalAmount > 0 ? roundMoney(totalAmount) : undefined,
       establishmentName: establishmentName && establishmentName.length > 0 ? establishmentName : undefined,
     };
   }


### PR DESCRIPTION
## What changed

- Added OCR number normalization for Brazilian receipt formats such as `R$ 5,50`, `5,50`, and `1.234,56`.
- Normalized OCR item fields before DTO validation, including common Portuguese aliases like `nome`, `quantidade`, `valorTotal`, and `totalGeral`.
- Updated the unvalidated JSON fallback so it no longer drops valid items when values arrive as pt-BR currency strings.
- Added focused OCR unit tests for number parsing, DTO normalization, and fallback parsing.

## Why

Production `/health` showed OCR jobs being processed but all ending in `failed`, with `completed: 0`. The deploy queue was not stuck; the extraction pipeline was rejecting or discarding item values returned by the model in Brazilian currency/string formats.

## Validation

- `npm test -- --runInBand ocr`
- `npm run build`
- `npm test -- --runInBand`

All checks passed locally.